### PR TITLE
Set compiler source and target and javadoc source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,9 @@
   </distributionManagement>
 
   <properties>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+
     <projectOwner>Red Hat, Inc.</projectOwner>
     <projectEmail>ncl-dev@redhat.com</projectEmail>
 
@@ -291,6 +294,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <source>${maven.compiler.source}</source>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The source level looks like it should be 8 based on the use of `org.codehaus.mojo.signature:java18:1.0`.

Adding the javadoc source level fixes the error (on Java 11):

```[WARNING] javadoc: warning - The code being documented uses modules but the packages defined in http://download.oracle.com/javase/7/docs/api/ are in the unnamed module.```