### PR TITLE
Assembly descriptor should not contain a filesystem-root relative ref…

### DIFF
--- a/cli/src/main/assembly/bin.xml
+++ b/cli/src/main/assembly/bin.xml
@@ -28,7 +28,7 @@
   <includeBaseDirectory>false</includeBaseDirectory>
   <dependencySets>
     <dependencySet>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <useProjectArtifact>true</useProjectArtifact>
       <unpack>true</unpack>
       <scope>runtime</scope>
@@ -45,7 +45,7 @@
       <includes>
         <include>META-INF/sisu/javax.inject.Named</include>
       </includes>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
     </fileSet>
   </fileSets>
 </assembly>


### PR DESCRIPTION
This fixes cross-platform issue where the assembly descriptor contains a filesystem-root relative reference (`/`), which is not cross-platform compatible.